### PR TITLE
nextflow: optional stylistic changes

### DIFF
--- a/flu-case-comparisons/README
+++ b/flu-case-comparisons/README
@@ -48,7 +48,7 @@ snakemake -c1
 
 ```
 cd cases/nextflow
-nextflow main.nf
+nextflow run main.nf
 ```
 
 ## Case study version 5: Morloc

--- a/flu-case-comparisons/cases/nextflow/main.nf
+++ b/flu-case-comparisons/cases/nextflow/main.nf
@@ -9,8 +9,8 @@ process RETRIEVE_DATA {
     val reffile
     
     output:
-    path "01-retrieved-data/metadata.json"
-    path "01-retrieved-data/sequence.fasta"
+    path "01-retrieved-data/metadata.json", emit: metadata
+    path "01-retrieved-data/sequence.fasta", emit: sequence
     
     script:
     """
@@ -60,7 +60,7 @@ process NAME_LEAVES {
     path class_table
     
     output:
-    path "labeled_tree.newick", emit: labeled_tree
+    path "labeled_tree.newick"
     
     script:
     template "nameLeaves.py"
@@ -83,11 +83,11 @@ workflow {
 
     RETRIEVE_DATA(params.reffile)
 
-    tree = MAKE_TREE(RETRIEVE_DATA.out[1])
+    tree = MAKE_TREE(RETRIEVE_DATA.out.sequence)
 
     class_table = CLASSIFY(tree, params.reffile)
 
-    labeled_tree = NAME_LEAVES(tree, RETRIEVE_DATA.out[0], class_table)
+    labeled_tree = NAME_LEAVES(tree, RETRIEVE_DATA.out.metadata, class_table)
 
     treeplot = PLOT(labeled_tree)
 }

--- a/flu-case-comparisons/cases/nextflow/main.nf
+++ b/flu-case-comparisons/cases/nextflow/main.nf
@@ -4,7 +4,7 @@ params.maxdate = "2021/01/14"
 params.email = "wena@mailinator.com"
 params.reffile = "/case/test-data/refs.txt"
 
-process retrieve_data {
+process RETRIEVE_DATA {
     input:
     val reffile
     
@@ -24,7 +24,7 @@ process retrieve_data {
     """
 }
 
-process make_tree {
+process MAKE_TREE {
     input:
     path tree
     
@@ -37,7 +37,7 @@ process make_tree {
     """
 }
 
-process classify {
+process CLASSIFY {
     input:
     path tree
     path reffile
@@ -51,7 +51,7 @@ process classify {
     """
 }
 
-process name_leaves {
+process NAME_LEAVES {
     publishDir "results", mode: "copy", overwrite: true
 
     input:
@@ -66,7 +66,7 @@ process name_leaves {
     template "nameLeaves.py"
 }
 
-process plot {
+process PLOT {
     publishDir "results", mode: "copy", overwrite: true
 
     input:
@@ -81,13 +81,13 @@ process plot {
 
 workflow {
 
-    retrieve_data(params.reffile)
+    RETRIEVE_DATA(params.reffile)
 
-    tree = make_tree(retrieve_data.out[1])
+    tree = MAKE_TREE(RETRIEVE_DATA.out[1])
 
-    class_table = classify(tree, params.reffile)
+    class_table = CLASSIFY(tree, params.reffile)
 
-    labeled_tree = name_leaves(tree, retrieve_data.out[0], class_table)
+    labeled_tree = NAME_LEAVES(tree, RETRIEVE_DATA.out[0], class_table)
 
-    treeplot = plot(labeled_tree)
+    treeplot = PLOT(labeled_tree)
 }

--- a/flu-case-comparisons/cases/nextflow/main.nf
+++ b/flu-case-comparisons/cases/nextflow/main.nf
@@ -87,7 +87,6 @@ workflow {
 
     ch_class_table = CLASSIFY(ch_tree, params.reffile)
 
-    ch_labeled_tree = NAME_LEAVES(ch_tree, RETRIEVE_DATA.out.metadata, ch_class_table)
-
-    ch_treeplot = PLOT(ch_labeled_tree)
+    ch_treeplot = NAME_LEAVES(ch_tree, RETRIEVE_DATA.out.metadata, ch_class_table)
+    | PLOT
 }

--- a/flu-case-comparisons/cases/nextflow/main.nf
+++ b/flu-case-comparisons/cases/nextflow/main.nf
@@ -83,11 +83,11 @@ workflow {
 
     RETRIEVE_DATA(params.reffile)
 
-    tree = MAKE_TREE(RETRIEVE_DATA.out.sequence)
+    ch_tree = MAKE_TREE(RETRIEVE_DATA.out.sequence)
 
-    class_table = CLASSIFY(tree, params.reffile)
+    ch_class_table = CLASSIFY(ch_tree, params.reffile)
 
-    labeled_tree = NAME_LEAVES(tree, RETRIEVE_DATA.out.metadata, class_table)
+    ch_labeled_tree = NAME_LEAVES(ch_tree, RETRIEVE_DATA.out.metadata, ch_class_table)
 
-    treeplot = PLOT(labeled_tree)
+    ch_treeplot = PLOT(ch_labeled_tree)
 }

--- a/flu-case-comparisons/cases/snakemake/Snakefile
+++ b/flu-case-comparisons/cases/snakemake/Snakefile
@@ -42,8 +42,8 @@ rule retrieve_data:
   input:
     reffile = "../../test-data/refs.txt"
   output:
-    "01-retrieved-data/metadata.json",
-    "01-retrieved-data/sequence.fasta"
+    metadata = "01-retrieved-data/metadata.json",
+    sequences = "01-retrieved-data/sequence.fasta"
   params:
     query = "Influenza+A+Virus[Organism]+H3N2[ALL]+HA[ALL]",
     mindate = "2021/01/01",


### PR DESCRIPTION
Some stylistic changes, loosely based on what I see in the nf-core repos.

* Capitalize process names
  example: [nf-core/rnaseq/subworkflows/nf-core/bam_sort_stats_samtools](https://github.com/nf-core/rnaseq/blob/b89fac32650aacc86fcda9ee77e00612a1d77066/subworkflows/nf-core/bam_sort_stats_samtools/main.nf#L5-L7)
* Name output channels, at least for processes the produce more than 2 sets of outputs 
  example: [nf-core/rnaseq/modules/nf-core/gunzip](https://github.com/nf-core/rnaseq/blob/b89fac32650aacc86fcda9ee77e00612a1d77066/modules/nf-core/gunzip/main.nf#L14-L15)
* Prefix channels with a "ch_"
  examples: [nf-core/modules searching for "ch_"](https://github.com/search?q=repo%3Anf-core%2Fmodules%20ch_&type=code)
* ~~Add a `nextflow.config` to automagically pull the docker image...after testing it still runs~~ nevermind, might be more complicated
  example: [nf-core/rnaseq/nextflow.config profiles](https://github.com/nf-core/rnaseq/blob/b89fac32650aacc86fcda9ee77e00612a1d77066/nextflow.config#L182-L191)